### PR TITLE
Added HMAC validation middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
 	"github.com/google/jsonapi"
 	"github.com/gorilla/mux"
+)
+
+var (
+	HmacKey string
 )
 
 func (m *TfcWebhookManager) sendWebhookResponse() {
@@ -123,6 +131,30 @@ func (m *TfcWebhookManager) FailedRunTask(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusOK)
 }
 
+func hmacValidationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if sha := r.Header.Get("x-tfc-task-signature"); sha != "" {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "Error reading request body", http.StatusInternalServerError)
+			}
+
+			h := hmac.New(sha512.New, []byte(HmacKey))
+			h.Write(body)
+
+			expectedSha := hex.EncodeToString(h.Sum(nil))
+			if !hmac.Equal([]byte(expectedSha), []byte(sha)) {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			}
+
+			// since the body was read, we need to restore it
+			r.Body = ioutil.NopCloser(bytes.NewReader(body))
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
 func Root(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "TFC Run Tasks Server root")
 }
@@ -135,6 +167,7 @@ func handleRequests() {
 	go manager.sendWebhookResponse()
 
 	r := mux.NewRouter()
+	r.Use(hmacValidationMiddleware)
 	r.HandleFunc("/", Root).Methods("GET")
 	r.HandleFunc("/success", manager.SuccessfulRunTask).Methods("POST")
 	r.HandleFunc("/failed", manager.FailedRunTask).Methods("POST")
@@ -143,5 +176,8 @@ func handleRequests() {
 }
 
 func main() {
+	if HmacKey = os.Getenv("TFC_TASK_HMAC_KEY"); HmacKey == "" {
+		HmacKey = "hashicorp"
+	}
 	handleRequests()
 }


### PR DESCRIPTION
This is the final piece of the puzzle for fully supporting run task webhooks as is. This PR introduces a middleware function that will validate the SHA512 sum sent in the request header `x-tfc-task-signature`. Validating the sum is entirely optional and the middleware will passthrough if the header is omitted. 

## Background:
When you create a run task you can specify an optional HMAC key for added security. When your run tasks execute, TFC will generate a SHA512 sum using this key and the webhook payload, and set it in the request header `x-tfc-task-signature`. This middleware will strip that header, generate a SHA512 sum and compare. If the sums are not equal it will return a `401 Unauthorized`. 

When the server is initialized it'll look for the key stored in the `TFC_TASK_HMAC_KEY` env variable, if not it'll default to "hashicorp".

## To test:

1. You'll need to have an instance of this server running with a public IP. 
2. Create a run task and set the HMAC key to `hashicorp` and the url: `http://<your-public-ip>/success` and attach it to your workspace.
3. In order for your run tasks to execute you'll need to trigger a run on that workspace.
4. If all goes well, your run task should pass!

No handler tests? Great question! I should probably add those :) 
